### PR TITLE
replace job_id_t with uint64_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,20 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
+##############################--g++4.7-plus--###################################
+if(EXISTS "gentoo_rules.cmake")
+  find_program(CXX NAMES g++-4.8.1 g++-4.7.2 g++-4.7.1 g++-4.7 g++)
+  execute_process(COMMAND sed -i 
+	"s|CMAKE_CXX_COMPILER [^ ]*|CMAKE_CXX_COMPILER ${CXX}|g" 
+	"gentoo_rules.cmake")
+  find_program(CC NAMES gcc-4.8.1 gcc-4.7.2 gcc-4.7.1 gcc-4.7 gcc)
+  execute_process(COMMAND sed -i 
+	"s|CMAKE_C_COMPILER [^ ]*|CMAKE_C_COMPILER ${CC}|g"
+	"gentoo_rules.cmake")
+else()
+  find_program(CMAKE_CXX_COMPILER NAMES g++-4.8.1 g++-4.7.2 g++-4.7.1 g++-4.7 g++)
+  find_program(CMAKE_C_COMPILER NAMES gcc-4.8.1 gcc-4.7.2 gcc-4.7.1 gcc-4.7 gcc)
+endif()
+################################################################################
 PROJECT(beanstalkpp)
 
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
@@ -39,12 +54,14 @@ ADD_EXECUTABLE(
 )
 TARGET_LINK_LIBRARIES(beanspeek ${Boost_LIBRARIES} beanstalkpp pthread)
 
-INSTALL(TARGETS beanstalkpp DESTINATION lib)
+INSTALL(TARGETS beanstalkpp LIBRARY DESTINATION lib)
 if(APPLE)
   set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 endif(APPLE)
 INSTALL(DIRECTORY . DESTINATION include/beanstalk++ FILES_MATCHING PATTERN "*.h" PATTERN "beanstalkpp.h" EXCLUDE PATTERN "*~" EXCLUDE PATTERN "*.git*" EXCLUDE PATTERN "*build*" EXCLUDE)
 INSTALL(FILES "beanstalkpp.h" DESTINATION include)
 
-SET(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -g -O0")
+SET(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -g -O0 -std=c++11")
 SET(CMAKE_CXX_FLAGS_RELEASE "-g0 -O2")
+SET(CMAKE_SHARED_LINKER_FLAGS "-static-libstdc++")
+SET(CMAKE_EXE_LINKER_FLAGS "-static-libstdc++")

--- a/client.cpp
+++ b/client.cpp
@@ -72,7 +72,7 @@ int Beanstalkpp::Client::put(const std::string& data) {
   
   // "INSERTED <id>\r\n" and "BURIED <id>\r\n" are accepted commands
   if(reply.compare("INSERTED") == 0 || reply.compare("BURIED") == 0) {
-    unsigned int id = this->tokenStream.expectInt();
+    uint64_t id = this->tokenStream.expectULL();
     this->tokenStream.expectEol();
     
     return id;
@@ -137,7 +137,7 @@ bool Beanstalkpp::Client::peekReady(Beanstalkpp::job_p_t& jobPtr) {
   }
   
   if(response.compare("FOUND") == 0) {
-    jobId = this->tokenStream.expectInt();
+    jobId = this->tokenStream.expectULL();
     payloadSize = this->tokenStream.expectInt();
     this->tokenStream.expectEol();
     

--- a/client.h
+++ b/client.h
@@ -96,7 +96,7 @@ public:
     this->sendCommand(s);
     
     this->tokenStream.expectString("RESERVED");
-    jobId = this->tokenStream.expectInt();
+    jobId = this->tokenStream.expectULL();
     payloadSize = this->tokenStream.expectInt();
     this->tokenStream.expectEol();
     
@@ -138,7 +138,7 @@ public:
     std::string response = this->tokenStream.nextString();
     
     if(response.compare("RESERVED") == 0) {
-      jobId = this->tokenStream.expectInt();
+      jobId = this->tokenStream.expectULL();
       payloadSize = this->tokenStream.expectInt();
       this->tokenStream.expectEol();
       

--- a/job.h
+++ b/job.h
@@ -23,13 +23,14 @@
 
 #include <boost/shared_ptr.hpp>
 #include <string>
+#include <cstdint>
 
 namespace Beanstalkpp {
   
 class Client;
 class Job;
 
-typedef unsigned int job_id_t;
+typedef uint64_t job_id_t;
 typedef boost::shared_ptr<Job> job_p_t;
 
 /**

--- a/tokenizedstream.cpp
+++ b/tokenizedstream.cpp
@@ -84,6 +84,17 @@ unsigned int Beanstalkpp::TokenizedStream::expectInt() {
   return ret;
 }
 
+uint64_t Beanstalkpp::TokenizedStream::expectULL() {
+  string s = this->nextString();
+  uint64_t ret;
+  
+  istringstream stream(s);
+  if(!(stream >> ret)) 
+    throw ServerException(ServerException::BAD_FORMAT, "Expected unsigned long long but got: " + s);
+  
+  return ret;
+}
+
 void Beanstalkpp::TokenizedStream::expectEol() {
   char *buf = this->readChunk(2);
   

--- a/tokenizedstream.h
+++ b/tokenizedstream.h
@@ -23,6 +23,7 @@
 
 #include <boost/asio.hpp>
 #include <string>
+#include <cstdint>
 
 namespace Beanstalkpp {
 
@@ -63,6 +64,14 @@ public:
    * @throws ServerException If there are no more characters left in this token string
    */
   unsigned int expectInt();
+
+  /**
+   * Treat the next token as an unsigned long long and return it
+   * 
+   * @throws ServerException If the next token is not an unsigned long long 
+   * @throws ServerException If there are no more characters left in this token string
+   */
+  uint64_t expectULL();
   
   /**
    * Expects the next token to be \r\n


### PR DESCRIPTION
Upstream of beanstalkd use uint64_t to store jobid, beanstalkpp has only supported unsigned int.
